### PR TITLE
improved browser support: use `transform` attribute (instead of using transform as CSS in the `style` attribute)

### DIFF
--- a/src/Bars.js
+++ b/src/Bars.js
@@ -161,12 +161,7 @@ const Bars = React.createClass({
 
         groupStyle = helpers.value(groupStyle, {seriesIndex, pointIndex, point, series, props});
 
-        const transform = 'translate3d(' + x + 'px,' + y + 'px,0px)';
-        const style = _.defaults({
-            transform,
-            WebkitTransform: transform,
-            MozTransform: transform
-        }, groupStyle);
+        const transform = 'translate(' + x + ',' + y + ')';
 
         const d = (scaleX.swap || scaleY.swap) ?
             ('M0,' + (-height / 2) + ' h' + (width) + ' v' + height + ' h' + (-width) + ' Z') :
@@ -180,7 +175,8 @@ const Bars = React.createClass({
         return <g
             key={pointIndex}
             className={className && (className + '-bar ' + className + '-bar-'  + pointIndex)}
-            style={style}>
+            style={groupStyle}
+            transform={transform}>
             <path
                 style={barStyle}
                 fill={point.color || series.color || this.color(seriesIndex)}

--- a/src/Pies.js
+++ b/src/Pies.js
@@ -182,10 +182,18 @@ const Pies = React.createClass({
         pieStyle = helpers.value([point.style, series.style, pieStyle], {seriesIndex, pointIndex, point, series, props});
         pieAttributes = helpers.value(pieAttributes, {seriesIndex, pointIndex, point, series, props});
 
+        // Used for setting `transform` (positioning) on the <path>
+        const {position, layerWidth, layerHeight} = props;
+        const innerRadius = this.getInnerRadius(props);
+        const outerRadius = this.getOuterRadius(props);
+        const coords = helpers.getCoords(position || '', layerWidth, layerHeight, outerRadius * 2, outerRadius * 2);
+        const transform = 'translate(' + (coords.x + outerRadius) + ',' + (coords.y + outerRadius) + ')';
+
         const pathProps = _.assign({
             style: pieStyle,
             fill: fillColor,
-            fillOpacity: point.opacity
+            fillOpacity: point.opacity,
+            transform: transform,
         }, pieAttributes);
 
         let pathList = [];
@@ -264,18 +272,9 @@ const Pies = React.createClass({
         const _startAngle = circularScale(0);
         this.color = helpers.colorFunc(colors);
 
-        const coords = helpers.getCoords(position || '', layerWidth, layerHeight, outerRadius * 2, outerRadius * 2);
-
-        const transform = 'translate3d(' + (coords.x + outerRadius) + 'px,' + (coords.y + outerRadius) + 'px,0px)';
-        const chartStyle = _.defaults({
-            transform,
-            WebkitTransform: transform,
-            MozTransform: transform
-        }, style);
-
         const halfPadAngle = props.padAngle / 2 || 0;
 
-        return <g className={className} style={chartStyle} opacity={opacity}>
+        return <g className={className} style={style} opacity={opacity}>
             {_.map(series, (series, index) => {
 
                 let {seriesVisible, seriesAttributes, seriesStyle} = props;

--- a/src/Ticks.js
+++ b/src/Ticks.js
@@ -136,25 +136,21 @@ const Ticks = React.createClass({
             return;
         }
 
-        tickAttributes = helpers.value(tickAttributes, {index, ticksLength, tick, props});
-        tickStyle = helpers.value(tickStyle, {index, ticksLength, tick, props});
-
         const pX = axis === 'x' ? x(tick.x) : helpers.normalizeNumber(position, layerWidth);
         const pY = axis === 'y' ? y(tick.y) : helpers.normalizeNumber(position, layerHeight);
 
         const transform = (scaleX.swap || scaleY.swap) ?
-            ('translate3d(' + pY + 'px,' + pX + 'px,0px)') :
-            ('translate3d(' + pX + 'px,' + pY + 'px,0px)');
+            ('translate(' + pY + ',' + pX + ')') :
+            ('translate(' + pX + ',' + pY + ')');
+        let {labelAttributes} = props;
 
-        const style = _.defaults({
-            transform,
-            WebkitTransform: transform,
-            MozTransform: transform
-        }, tickStyle);
+        tickAttributes = helpers.value(tickAttributes, {index, ticksLength, tick, props});
+        tickStyle = helpers.value(tickStyle, {index, ticksLength, tick, props});
 
         return <g
-            key={index} style={style}
+            key={index} style={tickStyle}
             className={className && (className + '-tick ' + className + '-tick-' + index)}
+            transform={transform}
             {...tickAttributes}>
             {this.renderLabel(ticksLength, tick, index)}
             {this.renderLine(ticksLength, tick, index)}


### PR DESCRIPTION
# Updated charts:
- [x] Pies
- [x] Bar
- [x] Ticks (labels + ticks)

NOTE: This PR won't cover ALL components for the sake of keeping internal development moving.
